### PR TITLE
Add VLA uncertainty evaluation paper entry

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -1742,5 +1742,30 @@
       "Computer Vision"
     ],
     "last_reviewed": "24 Sep 2025"
+  },
+  {
+    "id": 65,
+    "title": "Evaluating Uncertainty and Quality of Visual Language Action-enabled Robots",
+    "year": "22 Jul 2025",
+    "summary": "Introduces eight uncertainty and five quality metrics tailored for VLA robot controllers, showing through 908 manipulation trials that several measures align with expert judgments and distinguish low-quality executions beyond simple success rates.",
+    "sources": [
+      {
+        "type": "paper",
+        "title": "arXiv",
+        "url": "https://arxiv.org/abs/2507.17049"
+      },
+      {
+        "type": "pdf",
+        "title": "PDF",
+        "url": "http://arxiv.org/pdf/2507.17049"
+      }
+    ],
+    "tags": [
+      "Vision-Language Action",
+      "Uncertainty Estimation",
+      "Robotics Evaluation",
+      "Task Quality"
+    ],
+    "last_reviewed": "24 Sep 2025"
   }
 ]


### PR DESCRIPTION
## Summary
- add a catalog entry for the paper "Evaluating Uncertainty and Quality of Visual Language Action-enabled Robots"
- include links to the arXiv abstract and PDF along with tags describing its focus on uncertainty metrics and task quality

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d713a5d038832ea2b851b6a08ec0ff