### PR TITLE
Add ASIMOV semantic safety benchmark entry

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -1847,5 +1847,35 @@
       "Adversarial Attack"
     ],
     "last_reviewed": "24 Sep 2025"
+  },
+  {
+    "id": 69,
+    "title": "Generating Robot Constitutions & Benchmarks for Semantic Safety",
+    "year": "11 Mar 2025",
+    "summary": "Introduces the ASIMOV Benchmark to stress-test semantic safety in foundation-model robot controllers and presents an auto-amending pipeline that derives robot constitutions from real-world injury data, boosting rejection of unsafe actions via Constitutional AI.",
+    "sources": [
+      {
+        "type": "paper",
+        "title": "arXiv",
+        "url": "https://arxiv.org/abs/2503.08663v1"
+      },
+      {
+        "type": "pdf",
+        "title": "PDF",
+        "url": "http://arxiv.org/pdf/2503.08663v1"
+      },
+      {
+        "type": "website",
+        "title": "ASIMOV Benchmark",
+        "url": "https://asimov-benchmark.github.io"
+      }
+    ],
+    "tags": [
+      "Semantic Safety",
+      "Constitutional AI",
+      "Benchmark",
+      "Foundation Models"
+    ],
+    "last_reviewed": "24 Sep 2025"
   }
 ]


### PR DESCRIPTION
## Summary
- add a new catalog entry for "Generating Robot Constitutions & Benchmarks for Semantic Safety"
- include links to the paper, PDF, and project site along with summary and tags

## Testing
- jq empty vla_research.json

------
https://chatgpt.com/codex/tasks/task_e_68da2de2b01c832e911486f980b11868