### PR TITLE
Add HAZARD benchmark entry to research catalog

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -1877,5 +1877,35 @@
       "Foundation Models"
     ],
     "last_reviewed": "24 Sep 2025"
+  },
+  {
+    "id": 70,
+    "title": "HAZARD Challenge: Embodied Decision Making in Dynamically Changing Environments",
+    "year": "23 Jan 2024",
+    "summary": "Presents the HAZARD benchmark of disaster-themed virtual scenarios that stress-test how embodied agents using reinforcement learning, search, or LLM-based planning adapt to rapidly changing environments and unexpected hazards.",
+    "sources": [
+      {
+        "type": "paper",
+        "title": "arXiv",
+        "url": "https://arxiv.org/abs/2401.12975"
+      },
+      {
+        "type": "pdf",
+        "title": "PDF",
+        "url": "http://arxiv.org/pdf/2401.12975"
+      },
+      {
+        "type": "website",
+        "title": "Project page",
+        "url": "https://vis-www.cs.umass.edu/hazard/"
+      }
+    ],
+    "tags": [
+      "Safety Benchmark",
+      "Embodied Agents",
+      "Dynamic Environments",
+      "Disaster Response"
+    ],
+    "last_reviewed": "24 Sep 2025"
   }
 ]


### PR DESCRIPTION
## Summary
- add the HAZARD Challenge paper to the VLA research catalog with arXiv and project links
- tag the entry for safety benchmarking of embodied agents in dynamic environments

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da34db3c30832e95a958adf5024abd