### PR TITLE
Add ManiDreams entry to vla_research.json

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -4384,5 +4384,23 @@
       "Pedestrian Coordination"
     ],
     "last_reviewed": "22 Mar 2026"
+  },
+  {
+    "id": 164,
+    "title": "ManiDreams",
+    "year": "2026",
+    "summary": "ManiDreams project website.",
+    "sources": [
+      {
+        "type": "website",
+        "title": "Project page",
+        "url": "https://rice-robotpi-lab.github.io/ManiDreams/"
+      }
+    ],
+    "tags": [
+      "Vision-Language-Action"
+    ],
+    "last_reviewed": "25 Mar 2026"
   }
+
 ]


### PR DESCRIPTION
### Motivation
- Add the ManiDreams project to the repository's VLA research index so the project's page is discoverable from the curated dataset.

### Description
- Append a new record with `id: 164` to `vla_research.json` containing `title: "ManiDreams"`, `year: "2026"`, a short `summary`, a `sources` entry pointing to `https://rice-robotpi-lab.github.io/ManiDreams/`, `tags: ["Vision-Language-Action"]`, and `last_reviewed: "25 Mar 2026"`, following the existing schema and avoiding duplicate URLs.

### Testing
- Validated the file and the change with `python -m json.tool vla_research.json` and confirmed the append logic only added the new entry when the URL was not already present, and the checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c38e807ea8832e9b9155ae51f85420)