### PR TITLE
Add CAPGym entry to vla_research.json

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -4401,6 +4401,23 @@
       "Vision-Language-Action"
     ],
     "last_reviewed": "25 Mar 2026"
-  }
+  },
 
+  {
+    "id": 165,
+    "title": "CAPGym",
+    "year": "2026",
+    "summary": "CAPGym project website.",
+    "sources": [
+      {
+        "type": "website",
+        "title": "Project page",
+        "url": "https://capgym.github.io"
+      }
+    ],
+    "tags": [
+      "Vision-Language-Action"
+    ],
+    "last_reviewed": "02 Apr 2026"
+  }
 ]


### PR DESCRIPTION
### Motivation
- Add the CAPGym project record to the VLA research dataset so the project URL `https://capgym.github.io` is discoverable in `vla_research.json`.

### Description
- Appended a new JSON object to `vla_research.json` with `id` 165 and fields `title`, `year`, `summary`, `sources` (including the project URL), `tags`, and `last_reviewed` to match the existing schema.
- The insertion logic used `max(id)+1` to select the next sequential id and checked for an existing `https://capgym.github.io` source URL to avoid duplicates.
- Wrote the file with `ensure_ascii=False` to preserve Unicode characters and kept the overall JSON formatting consistent with existing entries.

### Testing
- Ran the Python insertion script which printed the new id and updated length of the dataset and completed without error.
- Validated the resulting JSON with `python -m json.tool /workspace/robotics-research.github.io/vla_research.json`, which returned `OK`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cde869e124832ebaddfc3e07585115)