### PR TITLE
Add UnrealRoboticsLab entry to vla_research.json

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -4402,7 +4402,6 @@
     ],
     "last_reviewed": "25 Mar 2026"
   },
-
   {
     "id": 165,
     "title": "CAPGym",
@@ -4419,5 +4418,23 @@
       "Vision-Language-Action"
     ],
     "last_reviewed": "02 Apr 2026"
+  },
+  {
+    "id": 166,
+    "title": "UnrealRoboticsLab",
+    "year": "2026",
+    "summary": "UnrealRoboticsLab GitHub repository.",
+    "sources": [
+      {
+        "type": "code",
+        "title": "Source code",
+        "url": "https://github.com/URLab-Sim/UnrealRoboticsLab"
+      }
+    ],
+    "tags": [
+      "Simulation",
+      "Robotics"
+    ],
+    "last_reviewed": "08 Apr 2026"
   }
 ]


### PR DESCRIPTION
### Motivation
- Add a new research index entry for the UnrealRoboticsLab GitHub repository so the project is discoverable in the `vla_research.json` dataset.

### Description
- Appended a new JSON object (`id: 166`) with `title`, `year`, `summary`, `sources` (including `https://github.com/URLab-Sim/UnrealRoboticsLab`), `tags`, and `last_reviewed` to `vla_research.json`.
- Insertion used a small Python script that avoids duplicate entries by checking existing source `url` values and also included a minor cleanup to restore the `∞` character for the `RobotArena` title.

### Testing
- Ran the insertion script which printed `entries 160 last id 166` confirming the new entry was added.
- Validated the updated JSON with `python -m json.tool vla_research.json` which succeeded (`JSON valid`).
- Committed the change with message `Add UnrealRoboticsLab entry to research JSON` and created commit `4547012`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d5f5e0743c832eafbc4f10ac58c61f)