### PR TITLE
Add sim1.github.io entry to VLA research JSON

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -4297,7 +4297,7 @@
   },
   {
     "id": 161,
-    "title": "RobotArena ∞: Scalable Robot Benchmarking via Real-to-Sim Translation",
+    "title": "RobotArena \u221e: Scalable Robot Benchmarking via Real-to-Sim Translation",
     "year": "2025",
     "summary": "Continuously evolving, reproducible benchmark for evaluating real-world-trained robot manipulation policies via real-to-sim translation and human feedback.",
     "sources": [
@@ -4436,5 +4436,22 @@
       "Robotics"
     ],
     "last_reviewed": "08 Apr 2026"
+  },
+  {
+    "id": 167,
+    "title": "sim1.github.io",
+    "year": "2026",
+    "summary": "sim1.github.io project website.",
+    "sources": [
+      {
+        "type": "website",
+        "title": "Project page",
+        "url": "https://internrobotics.github.io/sim1.github.io/"
+      }
+    ],
+    "tags": [
+      "Vision-Language-Action"
+    ],
+    "last_reviewed": "11 Apr 2026"
   }
 ]


### PR DESCRIPTION
### Motivation
- Add a missing project entry for `https://internrobotics.github.io/sim1.github.io/` to the curated VLA research catalog to keep the dataset up to date.
- Preserve the file schema and indexing by appending the new record with the next available `id`.

### Description
- Appended a new object (`id: 167`) to `vla_research.json` with `title: "sim1.github.io"`, `year: "2026"`, `summary`, `sources` referencing the provided URL, `tags: ["Vision-Language-Action"]`, and `last_reviewed: "11 Apr 2026"`.
- Used a short Python helper to compute the next `id` and write the pretty-printed JSON, and committed the change (`Add sim1.github.io entry to research catalog`).

### Testing
- Ran the append script which printed `added 167` to confirm the record insertion succeeded.
- Validated JSON formatting/parsing with `python -m json.tool vla_research.json`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dabb7ba1fc832e8261e01663d142b0)