### PR TITLE
Add Gemini Robotics entry to vla_research.json

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -4453,5 +4453,22 @@
       "Vision-Language-Action"
     ],
     "last_reviewed": "11 Apr 2026"
+  },
+  {
+    "id": 168,
+    "title": "Gemini Robotics",
+    "year": "2026",
+    "summary": "Google DeepMind model page for Gemini Robotics.",
+    "sources": [
+      {
+        "type": "website",
+        "title": "Project page",
+        "url": "https://deepmind.google/models/gemini-robotics/"
+      }
+    ],
+    "tags": [
+      "Vision-Language-Action"
+    ],
+    "last_reviewed": "14 Apr 2026"
   }
 ]


### PR DESCRIPTION
### Motivation
- Add a new catalog entry for Google DeepMind's Gemini Robotics model page to the VLA research index so the resource is discoverable alongside other vision-language-action work.

### Description
- Appended a JSON object to `vla_research.json` with `id: 168`, `title: "Gemini Robotics"`, `year: "2026"`, a short `summary`, a `sources` entry pointing to `https://deepmind.google/models/gemini-robotics/`, the tag `"Vision-Language-Action"`, and `last_reviewed: "14 Apr 2026"`.

### Testing
- Validated the updated file with `python -m json.tool vla_research.json > /tmp/vla_check.json`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69de774fc7e0832eb5eafc988e079897)