### PR TITLE
Add π0.7 blog entry to VLA research index

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -1627,7 +1627,7 @@
     "id": 62,
     "title": "On the Vulnerability of LLM/VLM-Controlled Robotics",
     "year": "15 Feb 2024",
-    "summary": "Characterizes how small instruction and perception perturbations degrade LLM/VLM robot controllers, offering perturbation strategies that expose 14\u201322% drops in task success.",
+    "summary": "Characterizes how small instruction and perception perturbations degrade LLM/VLM robot controllers, offering perturbation strategies that expose 14–22% drops in task success.",
     "sources": [
       {
         "type": "paper",
@@ -4297,7 +4297,7 @@
   },
   {
     "id": 161,
-    "title": "RobotArena \u221e: Scalable Robot Benchmarking via Real-to-Sim Translation",
+    "title": "RobotArena ∞: Scalable Robot Benchmarking via Real-to-Sim Translation",
     "year": "2025",
     "summary": "Continuously evolving, reproducible benchmark for evaluating real-world-trained robot manipulation policies via real-to-sim translation and human feedback.",
     "sources": [
@@ -4470,5 +4470,30 @@
       "Vision-Language-Action"
     ],
     "last_reviewed": "14 Apr 2026"
+  },
+  {
+    "id": 169,
+    "title": "π0.7: a Steerable Model with Emergent Capabilities",
+    "year": "16 Apr 2026",
+    "summary": "Physical Intelligence introduces π0.7, a steerable general-purpose robotic foundation model showing strong out-of-the-box dexterous performance and early compositional generalization across tasks, instructions, scenes, and robot embodiments.",
+    "sources": [
+      {
+        "type": "website",
+        "title": "Blog post",
+        "url": "https://www.pi.website/blog/pi07"
+      },
+      {
+        "type": "pdf",
+        "title": "π0.7 paper (PDF)",
+        "url": "https://www.pi.website/download/pi07.pdf"
+      }
+    ],
+    "tags": [
+      "Vision-Language-Action",
+      "Generalization",
+      "Robot Learning",
+      "Foundation Models"
+    ],
+    "last_reviewed": "16 Apr 2026"
   }
 ]


### PR DESCRIPTION
### Motivation
- Add the Physical Intelligence π0.7 blog post to the Vision-Language-Action research index so the site catalog includes the new release and associated PDF.
- Apply a couple of small typographic normalizations found while editing the file (range dash and project title symbol) for consistency.

### Description
- Appended a new JSON record (`id: 169`) to `vla_research.json` with `title`, `year`, `summary`, `sources` (blog URL and PDF), `tags`, and `last_reviewed` metadata.
- Ensured the new source includes the blog URL `https://www.pi.website/blog/pi07` and the PDF `https://www.pi.website/download/pi07.pdf`.
- Normalized two existing text entries (replaced `14\u201322%` with an en dash `14–22%` and updated the RobotArena title to include the infinity symbol) for typographic consistency.

### Testing
- Ran a small Python script that checks for an existing URL and appends the new entry only if absent, which reported `appended id 169`.
- Validated the modified JSON with `python -m json.tool vla_research.json`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e12b0b4830832e901a38ce54409188)