### PR TITLE
Add ROBOTIS Product Viewer entry to vla_research.json

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -4495,5 +4495,23 @@
       "Foundation Models"
     ],
     "last_reviewed": "16 Apr 2026"
+  },
+  {
+    "id": 170,
+    "title": "ROBOTIS Product Viewer",
+    "year": "2026",
+    "summary": "ROBOTIS product viewer webpage for exploring robot hardware offerings and specifications.",
+    "sources": [
+      {
+        "type": "website",
+        "title": "Product page",
+        "url": "https://www.robotis.us/product-viewer/"
+      }
+    ],
+    "tags": [
+      "Robotics",
+      "Resource"
+    ],
+    "last_reviewed": "19 Apr 2026"
   }
 ]


### PR DESCRIPTION
### Motivation
- Add the ROBOTIS product viewer webpage to the research catalog so the robot hardware resource is discoverable from the repository.

### Description
- Inserted a new catalog entry (id: 170) into `vla_research.json` with `title` "ROBOTIS Product Viewer", `year` "2026", a short `summary`, a `sources` entry pointing to `https://www.robotis.us/product-viewer/`, `tags` ["Robotics","Resource"], and `last_reviewed` set to `19 Apr 2026`.

### Testing
- Validated the JSON with `python -m json.tool vla_research.json` which succeeded, and reviewed the change with `git diff --stat` to confirm the insertion.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e4b5a22270832e9e77b784caa4aef4)