### PR TITLE
Add Retain website entry to vla_research.json (id 171)

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -1627,7 +1627,7 @@
     "id": 62,
     "title": "On the Vulnerability of LLM/VLM-Controlled Robotics",
     "year": "15 Feb 2024",
-    "summary": "Characterizes how small instruction and perception perturbations degrade LLM/VLM robot controllers, offering perturbation strategies that expose 14–22% drops in task success.",
+    "summary": "Characterizes how small instruction and perception perturbations degrade LLM/VLM robot controllers, offering perturbation strategies that expose 14\u201322% drops in task success.",
     "sources": [
       {
         "type": "paper",
@@ -4297,7 +4297,7 @@
   },
   {
     "id": 161,
-    "title": "RobotArena ∞: Scalable Robot Benchmarking via Real-to-Sim Translation",
+    "title": "RobotArena \u221e: Scalable Robot Benchmarking via Real-to-Sim Translation",
     "year": "2025",
     "summary": "Continuously evolving, reproducible benchmark for evaluating real-world-trained robot manipulation policies via real-to-sim translation and human feedback.",
     "sources": [
@@ -4473,9 +4473,9 @@
   },
   {
     "id": 169,
-    "title": "π0.7: a Steerable Model with Emergent Capabilities",
+    "title": "\u03c00.7: a Steerable Model with Emergent Capabilities",
     "year": "16 Apr 2026",
-    "summary": "Physical Intelligence introduces π0.7, a steerable general-purpose robotic foundation model showing strong out-of-the-box dexterous performance and early compositional generalization across tasks, instructions, scenes, and robot embodiments.",
+    "summary": "Physical Intelligence introduces \u03c00.7, a steerable general-purpose robotic foundation model showing strong out-of-the-box dexterous performance and early compositional generalization across tasks, instructions, scenes, and robot embodiments.",
     "sources": [
       {
         "type": "website",
@@ -4484,7 +4484,7 @@
       },
       {
         "type": "pdf",
-        "title": "π0.7 paper (PDF)",
+        "title": "\u03c00.7 paper (PDF)",
         "url": "https://www.pi.website/download/pi07.pdf"
       }
     ],
@@ -4513,5 +4513,22 @@
       "Resource"
     ],
     "last_reviewed": "19 Apr 2026"
+  },
+  {
+    "id": 171,
+    "title": "Retain",
+    "year": "2026",
+    "summary": "Retain project website.",
+    "sources": [
+      {
+        "type": "website",
+        "title": "Project page",
+        "url": "https://retain.yajatyadav.com"
+      }
+    ],
+    "tags": [
+      "Vision-Language-Action"
+    ],
+    "last_reviewed": "23 Apr 2026"
   }
 ]


### PR DESCRIPTION
### Motivation
- Add a new research record pointing to the Retain project website at `https://retain.yajatyadav.com` to keep the `vla_research.json` catalog up to date.
- Ensure the entry is unique and the JSON file remains well-formed after the update.

### Description
- Appended a new object to `vla_research.json` with `id` 171, `title` "Retain", `year` "2026", a short `summary`, a `sources` entry for the project page (`https://retain.yajatyadav.com`), `tags` set to `"Vision-Language-Action"`, and `last_reviewed` set to `23 Apr 2026`.
- The update was written using `json.dumps(..., indent=2)`, which resulted in non-ASCII characters elsewhere in the file being escaped (for example, `∞` -> `\u221e`, `π` -> `\u03c0`, and en-dash characters to `\u2013`).
- The file was saved back to disk with pretty-printed JSON formatting.

### Testing
- A duplicate-check script confirmed the URL was not already present and reported `added 171`.
- `python -m json.tool vla_research.json` was run and returned success, confirming the file is valid JSON.
- A quick file preview of the tail of `vla_research.json` was produced to verify the new entry appears as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea569724e4832e8873cfde4449e1a6)