### PR TITLE
Add ACoT-VLA entry to vla_research.json

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -4530,5 +4530,35 @@
       "Vision-Language-Action"
     ],
     "last_reviewed": "23 Apr 2026"
+  },
+  {
+    "id": 172,
+    "title": "ACoT-VLA: Action Chain-of-Thought for Vision-Language-Action Models",
+    "year": "16 Jan 2026",
+    "summary": "Introduces ACoT-VLA, a vision-language-action architecture that reasons directly in action space via explicit and implicit action reasoners to improve grounded policy learning for manipulation in real and simulated environments.",
+    "sources": [
+      {
+        "type": "paper",
+        "title": "arXiv",
+        "url": "https://arxiv.org/abs/2601.11404"
+      },
+      {
+        "type": "pdf",
+        "title": "PDF",
+        "url": "https://arxiv.org/pdf/2601.11404"
+      },
+      {
+        "type": "code",
+        "title": "Source code",
+        "url": "https://github.com/AgibotTech/ACoT-VLA"
+      }
+    ],
+    "tags": [
+      "Vision-Language-Action",
+      "Robot Manipulation",
+      "Action Reasoning",
+      "Foundation Models"
+    ],
+    "last_reviewed": "24 Apr 2026"
   }
 ]


### PR DESCRIPTION
### Motivation
- Add the requested arXiv entry for ACoT-VLA to the research index so the paper PDF `https://arxiv.org/pdf/2601.11404` is discoverable in the repository.

### Description
- Appended a new JSON entry with `id: 172` for "ACoT-VLA: Action Chain-of-Thought for Vision-Language-Action Models" including title, date, summary, `sources` (arXiv abstract, PDF, and code), `tags`, and `last_reviewed` metadata.
- The addition was inserted at the end of `vla_research.json` and avoids duplicating an existing `https://arxiv.org/pdf/2601.11404` URL by checking existing entries before append.

### Testing
- Ran the append script which performed a duplicate-URL check and completed successfully (script reported the entry was appended). 
- Validated JSON syntax with `python -m json.tool vla_research.json`, which returned OK (no syntax errors).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eb7b5e1d50832eb0641865f25ccb79)