### PR TITLE
Add ResVLA (arXiv:2604.21391) to vla_research.json

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -4560,5 +4560,30 @@
       "Foundation Models"
     ],
     "last_reviewed": "24 Apr 2026"
+  },
+  {
+    "id": 173,
+    "title": "From Noise to Intent: Anchoring Generative VLA Policies with Residual Bridges",
+    "year": "23 Apr 2026",
+    "summary": "Introduces ResVLA, a generative vision-language-action policy that shifts from generation-from-noise to refinement-from-intent by decomposing control into low-frequency intent anchors and high-frequency residual dynamics, improving robustness and convergence in simulation and real-robot experiments.",
+    "sources": [
+      {
+        "type": "paper",
+        "title": "arXiv",
+        "url": "https://arxiv.org/abs/2604.21391"
+      },
+      {
+        "type": "pdf",
+        "title": "PDF",
+        "url": "https://arxiv.org/pdf/2604.21391"
+      }
+    ],
+    "tags": [
+      "Vision-Language-Action",
+      "Robot Manipulation",
+      "Diffusion Policy",
+      "Embodied AI"
+    ],
+    "last_reviewed": "26 Apr 2026"
   }
 ]


### PR DESCRIPTION
### Motivation
- Add a catalog entry for the new VLA policy paper (arXiv:2604.21391) so the research catalog includes the ResVLA work on anchoring generative VLA policies with residual bridges.

### Description
- Append a new JSON object (`id: 173`) to `vla_research.json` containing the paper title, publication date, concise summary, `sources` with the arXiv `/abs/2604.21391` and `/pdf/2604.21391` links, tags `["Vision-Language-Action","Robot Manipulation","Diffusion Policy","Embodied AI"]`, and `last_reviewed` set to `26 Apr 2026`.

### Testing
- Validated the file with `python -m json.tool vla_research.json`, inspected the working tree with `git status --short`, and verified the commit via `git show --stat --oneline -1`, and all checks completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ee3419fe18832eb89c8f068fcd3921)