### PR TITLE
Add HOIPage entry to VLA research JSON

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -1627,7 +1627,7 @@
     "id": 62,
     "title": "On the Vulnerability of LLM/VLM-Controlled Robotics",
     "year": "15 Feb 2024",
-    "summary": "Characterizes how small instruction and perception perturbations degrade LLM/VLM robot controllers, offering perturbation strategies that expose 14–22% drops in task success.",
+    "summary": "Characterizes how small instruction and perception perturbations degrade LLM/VLM robot controllers, offering perturbation strategies that expose 14\u201322% drops in task success.",
     "sources": [
       {
         "type": "paper",
@@ -4297,7 +4297,7 @@
   },
   {
     "id": 161,
-    "title": "RobotArena ∞: Scalable Robot Benchmarking via Real-to-Sim Translation",
+    "title": "RobotArena \u221e: Scalable Robot Benchmarking via Real-to-Sim Translation",
     "year": "2025",
     "summary": "Continuously evolving, reproducible benchmark for evaluating real-world-trained robot manipulation policies via real-to-sim translation and human feedback.",
     "sources": [
@@ -4473,9 +4473,9 @@
   },
   {
     "id": 169,
-    "title": "π0.7: a Steerable Model with Emergent Capabilities",
+    "title": "\u03c00.7: a Steerable Model with Emergent Capabilities",
     "year": "16 Apr 2026",
-    "summary": "Physical Intelligence introduces π0.7, a steerable general-purpose robotic foundation model showing strong out-of-the-box dexterous performance and early compositional generalization across tasks, instructions, scenes, and robot embodiments.",
+    "summary": "Physical Intelligence introduces \u03c00.7, a steerable general-purpose robotic foundation model showing strong out-of-the-box dexterous performance and early compositional generalization across tasks, instructions, scenes, and robot embodiments.",
     "sources": [
       {
         "type": "website",
@@ -4484,7 +4484,7 @@
       },
       {
         "type": "pdf",
-        "title": "π0.7 paper (PDF)",
+        "title": "\u03c00.7 paper (PDF)",
         "url": "https://www.pi.website/download/pi07.pdf"
       }
     ],
@@ -4602,5 +4602,22 @@
       "Vision-Language-Action"
     ],
     "last_reviewed": "01 May 2026"
+  },
+  {
+    "id": 175,
+    "title": "HOIPage",
+    "year": "2026",
+    "summary": "HOIPage project website.",
+    "sources": [
+      {
+        "type": "website",
+        "title": "Project page",
+        "url": "https://craigleili.github.io/projects/hoipage/"
+      }
+    ],
+    "tags": [
+      "Vision-Language-Action"
+    ],
+    "last_reviewed": "03 May 2026"
   }
 ]


### PR DESCRIPTION
### Motivation
- Add a new project resource for HOIPage into the VLA research dataset to keep the catalog current.
- Ensure the dataset includes the provided project URL so it can be discovered by consumers of the JSON.

### Description
- Appended a new entry to `vla_research.json` with `id` 175, `title` "HOIPage", `year` "2026", `summary` "HOIPage project website.", a single website `source` pointing to `https://craigleili.github.io/projects/hoipage/`, `tags` set to `["Vision-Language-Action"]`, and `last_reviewed` "03 May 2026".
- Re-serialized `vla_research.json` as part of the update which caused non-ASCII characters in existing entries to be escaped (for example, "∞" -> `\u221e` and "π" -> `\u03c0`) due to JSON dumping behavior.

### Testing
- Validated the resulting JSON with `python -m json.tool vla_research.json`, which succeeded.
- Ran the update script that appended the entry and printed the new assigned id `175`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f71ac360c4832e8ea6815b563f3de0)