### PR TITLE
Add arXiv entry 2605.00583v1 (Jailbreaking Vision-Language Models Through the Visual Modality)

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -4619,5 +4619,29 @@
       "Vision-Language-Action"
     ],
     "last_reviewed": "03 May 2026"
+  },
+  {
+    "id": 176,
+    "title": "Jailbreaking Vision-Language Models Through the Visual Modality",
+    "year": "01 May 2026",
+    "summary": "Presents four visual-modality jailbreak attacks against frontier vision-language models, showing that harmful intent can bypass text-centric safeguards via visual ciphers, benign substitutions, edited text-in-image context, and visual analogies.",
+    "sources": [
+      {
+        "type": "paper",
+        "title": "arXiv",
+        "url": "https://arxiv.org/abs/2605.00583v1"
+      },
+      {
+        "type": "pdf",
+        "title": "PDF",
+        "url": "https://arxiv.org/pdf/2605.00583v1"
+      }
+    ],
+    "tags": [
+      "Vision-Language Models",
+      "AI Safety",
+      "Adversarial Attacks"
+    ],
+    "last_reviewed": "05 May 2026"
   }
 ]


### PR DESCRIPTION
### Motivation
- Add a missing research record for arXiv:2605.00583v1 to the site index so the paper is discoverable alongside other VLA and VLM safety work.

### Description
- Appended a new JSON entry (`id: 176`) to `vla_research.json` containing the paper title, publication date, concise summary, arXiv abstract and PDF source links, relevant tags, and `last_reviewed` metadata.

### Testing
- Validated the updated file with `python -m json.tool vla_research.json` which succeeded, and verified arXiv metadata retrieval from the export API returned the expected `title`, `published`, and `summary`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa258a92e0832eb55529ce91a6eb6d)