### PR TITLE
Add semantic world models research entry

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -4664,5 +4664,46 @@
       "Low-Light Vision"
     ],
     "last_reviewed": "08 May 2026"
+  },
+  {
+    "id": 178,
+    "title": "Reconstruction or Semantics? What Makes a Latent Space Useful for Robotic World Models",
+    "year": "07 May 2026",
+    "summary": "Evaluates reconstruction-aligned and semantics-aligned latent spaces for action-conditioned latent diffusion world models in robotics, showing that semantic encoders such as V-JEPA 2.1, Web-DINO, and SigLIP 2 better preserve policy-relevant structure across planning, latent-quality, downstream VLA, and robustness metrics than visual fidelity alone would suggest.",
+    "sources": [
+      {
+        "type": "website",
+        "title": "Project page",
+        "url": "https://hskalin.github.io/semantic-wm/"
+      },
+      {
+        "type": "paper",
+        "title": "arXiv",
+        "url": "https://arxiv.org/abs/2605.06388"
+      },
+      {
+        "type": "pdf",
+        "title": "PDF",
+        "url": "https://arxiv.org/pdf/2605.06388"
+      },
+      {
+        "type": "code",
+        "title": "Source code",
+        "url": "https://github.com/chandar-lab/semantic-wm"
+      },
+      {
+        "type": "model",
+        "title": "Hugging Face",
+        "url": "https://huggingface.co/Nilaksh404/semantic-wm"
+      }
+    ],
+    "tags": [
+      "World Models",
+      "Latent Diffusion",
+      "Robot Control",
+      "Vision-Language-Action",
+      "Semantic Representation"
+    ],
+    "last_reviewed": "14 May 2026"
   }
 ]


### PR DESCRIPTION
### Motivation
- Add a new research entry for the paper/project hosted at `https://hskalin.github.io/semantic-wm/` to keep the `vla_research.json` index current.
- Surface links to the project page, arXiv paper, PDF, source code, and model artifacts for discovery and citation.

### Description
- Appended a new object to `vla_research.json` with `id` 178 and `title` "Reconstruction or Semantics? What Makes a Latent Space Useful for Robotic World Models".
- The entry includes `year`, a concise `summary`, a `sources` array with the project page, arXiv, PDF, GitHub, and Hugging Face links, a set of `tags` (e.g., "World Models", "Latent Diffusion", "Robot Control", "Vision-Language-Action", "Semantic Representation"), and `last_reviewed` set to "14 May 2026".
- The file was reserialized/pretty-printed as valid JSON and staged for commit in `vla_research.json`.

### Testing
- Verified JSON validity with `python -m json.tool vla_research.json >/dev/null`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a059a1e2774832e8b8dbee31c0ddad0)