### PR TITLE
Add Qwen-VLA research entry to vla_research.json

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -4751,5 +4751,47 @@
       "Chain-of-Thought"
     ],
     "last_reviewed": "29 May 2026"
+  },
+  {
+    "id": 180,
+    "title": "Qwen-VLA: Unifying Vision-Language-Action Modeling across Tasks, Environments, and Robot Embodiments",
+    "year": "28 May 2026",
+    "summary": "Introduces Qwen-VLA, a unified embodied foundation model that extends Qwen's vision-language stack to continuous action and trajectory generation with a DiT-based action decoder, using embodiment-aware prompt conditioning and a shared action-and-trajectory prediction framework for manipulation, navigation, and trajectory prediction across robot embodiments.",
+    "sources": [
+      {
+        "type": "paper",
+        "title": "arXiv",
+        "url": "https://arxiv.org/abs/2605.30280"
+      },
+      {
+        "type": "pdf",
+        "title": "PDF",
+        "url": "https://arxiv.org/pdf/2605.30280"
+      },
+      {
+        "type": "code",
+        "title": "Source code",
+        "url": "https://github.com/QwenLM/Qwen-VLA"
+      },
+      {
+        "type": "article",
+        "title": "Qwen blog",
+        "url": "https://qwen.ai/blog?id=qwenvla"
+      },
+      {
+        "type": "video",
+        "title": "Demo",
+        "url": "https://qianwen-res.oss-accelerate.aliyuncs.com/Qwen-VLA/demo.mp4"
+      }
+    ],
+    "tags": [
+      "Vision-Language-Action",
+      "Embodied Foundation Models",
+      "Robot Manipulation",
+      "Navigation",
+      "Trajectory Prediction",
+      "Cross-Embodiment Generalization"
+    ],
+    "last_reviewed": "30 May 2026"
   }
 ]


### PR DESCRIPTION
### Motivation
- Add a new research entry for the Qwen-VLA paper/repository so the VLA research index includes the arXiv record, code, demo, and relevant tags for cross-embodiment vision-language-action work.

### Description
- Appended a new entry (`id`: 180) to `vla_research.json` with `title`, `year`, concise `summary`, `sources` (arXiv, PDF, GitHub code, blog, demo), `tags` (Vision-Language-Action, Embodied Foundation Models, Robot Manipulation, Navigation, Trajectory Prediction, Cross-Embodiment Generalization), and `last_reviewed` date.

### Testing
- Validated the resulting JSON with `python -m json.tool vla_research.json >/tmp/vla_research.valid.json`, which succeeded (the add script also reported `added id 180`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b12d7c948832e8056bd8259083fd9)