### PR TITLE
Add Interlatent “Modern AI Robotics from First Principles” entry to vla_research.json

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -4820,5 +4820,27 @@
       "AI Safety"
     ],
     "last_reviewed": "11 Jun 2026"
+  },
+  {
+    "id": 182,
+    "title": "An Overview of Modern AI Robotics from First Principles",
+    "year": "10 Jun 2026",
+    "summary": "A first-principles primer on modern robot learning that frames robot policies as observation-to-action functions while emphasizing physical-world inference time, VLA architectures, action chunking, edge-versus-cloud latency budgets, the robotics data bottleneck, training ladders, and self-improving robot learning loops.",
+    "sources": [
+      {
+        "type": "article",
+        "title": "Interlatent blog",
+        "url": "https://interlatent.com/blog/interlatent-modern-ai-robotics-first-principles"
+      }
+    ],
+    "tags": [
+      "Vision-Language-Action",
+      "Robot Learning",
+      "Physical AI",
+      "Action Chunking",
+      "Latency",
+      "Self-Improving Robots"
+    ],
+    "last_reviewed": "11 Jun 2026"
   }
 ]


### PR DESCRIPTION
### Motivation
- Keep the VLA research index current by adding a newly published Interlatent blog primer that frames modern robot learning from first principles. 
- Capture canonical metadata (title, date, summary, source URL, tags, review date) so the article is discoverable in the dataset.

### Description
- Appended a new JSON entry with `id: 182` to `vla_research.json` containing `title`, `year`, `summary`, `sources` (with the Interlatent blog URL), `tags`, and `last_reviewed` fields. 
- Ensured the entry matches the blog slug `interlatent-modern-ai-robotics-first-principles` and aligns with existing record structure.
- Committed the updated `vla_research.json` to the repository.

### Testing
- Verified the blog page is reachable with an automated `python` `urlopen` request that returned HTTP `200` and the expected slug in the site bundle. 
- Ran `python -m json.tool vla_research.json >/tmp/vla_research.json.valid` to validate JSON formatting and structure. 
- Ran `git diff --check` to ensure no whitespace or diff errors and committed the change (`git` reported a successful commit).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2aaa3cc6bc832e87154c8a3ec868bf)