### PR TITLE
Add BadWorld research entry to vla_research.json

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -4820,5 +4820,41 @@
       "AI Safety"
     ],
     "last_reviewed": "11 Jun 2026"
+  },
+  {
+    "id": 182,
+    "title": "BadWorld: Adversarial Attacks on World Models",
+    "year": "15 Jun 2026",
+    "summary": "Introduces BadWorld, a label-free adversarial attack framework for visual world models that perturbs a single context image to induce catastrophic degradation in action-conditioned future rollouts across unseen user controls, exposing robustness risks in autoregressive world models.",
+    "sources": [
+      {
+        "type": "paper",
+        "title": "arXiv",
+        "url": "https://arxiv.org/abs/2606.16519"
+      },
+      {
+        "type": "pdf",
+        "title": "PDF",
+        "url": "https://arxiv.org/pdf/2606.16519"
+      },
+      {
+        "type": "website",
+        "title": "Project page",
+        "url": "https://linghuiishen.github.io/BadWorld/"
+      },
+      {
+        "type": "code",
+        "title": "Source code",
+        "url": "https://github.com/LinghuiiShen/BadWorld"
+      }
+    ],
+    "tags": [
+      "World Models",
+      "Adversarial Attacks",
+      "Visual World Models",
+      "Action-Conditioned Rollouts",
+      "AI Safety"
+    ],
+    "last_reviewed": "16 Jun 2026"
   }
 ]


### PR DESCRIPTION
### Motivation
- Add a recent arXiv paper that exposes adversarial vulnerabilities in visual world models to the VLA research listing to keep the dataset current and track relevant code and project links.

### Description
- Appended a new entry with `id: 182` for "BadWorld: Adversarial Attacks on World Models" including publication date, concise summary, and `last_reviewed` date.
- Included `sources` entries for the arXiv page, PDF, project page, and GitHub repository, and added tags: `World Models`, `Adversarial Attacks`, `Visual World Models`, `Action-Conditioned Rollouts`, and `AI Safety`.
- Updated `vla_research.json` formatting to ensure consistent JSON indentation and ASCII encoding.

### Testing
- Verified JSON validity with `python3 -m json.tool vla_research.json >/tmp/vla_research.json.formatted` which completed successfully.
- Confirmed the file contains the new entry by loading and inspecting the JSON in a short Python check that printed the final entry metadata successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3110b67074832eb35641867a2f5529)