### PR TITLE
Add Binh's LeRobot Notes entry to vla_research.json

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -4905,5 +4905,26 @@
       "AI Safety"
     ],
     "last_reviewed": "18 Jun 2026"
+  },
+  {
+    "id": 185,
+    "title": "Binh's LeRobot Notes",
+    "year": "25 Jun 2026",
+    "summary": "A survey of LeRobot's visuomotor policies, inference regimes, and reward models, collecting practical notes on robot learning architectures and deployment considerations for the LeRobot ecosystem.",
+    "sources": [
+      {
+        "type": "website",
+        "title": "Binh's LeRobot Notes",
+        "url": "https://lerobot.binhph.am/"
+      }
+    ],
+    "tags": [
+      "LeRobot",
+      "Vision-Language-Action",
+      "Visuomotor Policies",
+      "Robot Learning",
+      "Reward Models"
+    ],
+    "last_reviewed": "25 Jun 2026"
   }
 ]


### PR DESCRIPTION
### Motivation
- Add the LeRobot notes website to the VLA research index so the collection references a recent survey of LeRobot visuomotor policies and deployment notes.

### Description
- Appended a new JSON object to `vla_research.json` (id 185) with `title`, `year`, `summary`, `sources` (website URL), `tags`, and `last_reviewed` fields.

### Testing
- Ran `python3 -m json.tool vla_research.json >/dev/null` and `git diff --check`, both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3da4210c28832eac8fdc3c0292f44d)