### PR TITLE
Add NAC (Neural Action Codec) entry to vla_research.json

### DIFF
--- a/vla_research.json
+++ b/vla_research.json
@@ -4926,5 +4926,37 @@
       "Reward Models"
     ],
     "last_reviewed": "25 Jun 2026"
+  },
+  {
+    "id": 186,
+    "title": "NAC: Neural Action Codec for Vision-Language-Action Models",
+    "year": "2026",
+    "summary": "Introduces NAC, a learned action tokenizer for vision-language-action models that treats robot action chunks as multi-channel 1D signals and compresses them with a multi-scale RVQGAN audio-codec architecture, achieving lower reconstruction error and higher manipulation success than binning, FAST, and prior VQ tokenizers.",
+    "sources": [
+      {
+        "type": "website",
+        "title": "Project page",
+        "url": "https://www.ahadjawaid.com/nac"
+      },
+      {
+        "type": "pdf",
+        "title": "PDF",
+        "url": "https://www.ahadjawaid.com/nac/Neural_Action_Codec.pdf"
+      },
+      {
+        "type": "code",
+        "title": "GitHub",
+        "url": "https://github.com/ahadjawaid/nac"
+      }
+    ],
+    "tags": [
+      "Vision-Language-Action",
+      "Action Tokenization",
+      "Robot Learning",
+      "Neural Audio Codecs",
+      "Residual Vector Quantization",
+      "Behavioral Cloning"
+    ],
+    "last_reviewed": "29 Jun 2026"
   }
 ]


### PR DESCRIPTION
### Motivation
- Make the NAC (Neural Action Codec) project discoverable from the VLA research index by adding a structured entry linking the project page, PDF, and code repository.

### Description
- Appended a new research record with `id: 186` titled "NAC: Neural Action Codec for Vision-Language-Action Models" to `vla_research.json`.
- The entry includes a concise `summary`, `year` set to "2026", `sources` pointing to the project page (`https://www.ahadjawaid.com/nac`), PDF (`/nac/Neural_Action_Codec.pdf`), and GitHub (`https://github.com/ahadjawaid/nac`).
- Added relevant `tags` for discoverability: "Vision-Language-Action", "Action Tokenization", "Robot Learning", "Neural Audio Codecs", "Residual Vector Quantization", and "Behavioral Cloning".
- Set `last_reviewed` metadata to "29 Jun 2026" and appended the new object to the end of the existing JSON array.

### Testing
- Validated JSON syntax with `python -m json.tool vla_research.json >/tmp/vla_research.json.valid`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4288d126e8832e99e3a8219a459a27)